### PR TITLE
fix link to NeuroTechX website in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you're new to Git and want to learn how to fork this repo, make your own addi
 
 ### Community
 
-This project is maintained by the [NeuroTechX](www.neurotechx.com) community. Join our Slack to check out our #interactive-tutorial channel, where discussions about EEG101 take place.
+This project is maintained by the [NeuroTechX](http://www.neurotechx.com) community. Join our Slack to check out our #interactive-tutorial channel, where discussions about EEG101 take place.
 
 ## How can I contribute?
 


### PR DESCRIPTION
The link to the NeuroTechX website links to https://github.com/NeuroTechX/eeg-101/blob/master/www.neurotechx.com as a relative link.

I've added http to the url schema so that github doesn't interpret it as a relative link.

[relative links in github markdown readme files](https://help.github.com/articles/about-readmes/#relative-links-and-image-paths-in-readme-files)