### PR TITLE
Upgrade Muse's implementation to 6.0.x

### DIFF
--- a/EEG101/android/app/src/main/java/com/eeg_project/components/connector/ConnectorModule.java
+++ b/EEG101/android/app/src/main/java/com/eeg_project/components/connector/ConnectorModule.java
@@ -105,7 +105,7 @@ public class ConnectorModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void disconnectDevice() {
         if (appState.connectedMuse != null) {
-            appState.connectedMuse.disconnect(true);
+            appState.connectedMuse.disconnect();
             appState.connectedMuse.unregisterAllListeners();
         }
     }


### PR DESCRIPTION
> MuseManager::disconnect(bool) no longer takes a boolean parameter and has
> been replaced with MuseManager::disconnect() which takes no parameters.
> If you want to unregister all listeners when disconnecting, it is
> recommended that you call unregister_all_listeners after you receive the
> DISCONNECTED connection listener callback.

ref: http://forum.choosemuse.com/t/libmuse-for-android-ios-and-unity-example-updated-to-6-0-0/1216